### PR TITLE
[Downsampling] Adding downsampling to real-time visualization 

### DIFF
--- a/dual_recording_ieee1588.py
+++ b/dual_recording_ieee1588.py
@@ -211,14 +211,29 @@ def record_dual(vid_file, max_frames=100, num_cams=4, frame_pause=0, preview = T
                 if (0. < resize <= 1.0) and isinstance(resize, float):
                     preview_im = cv2.resize(preview_im, dsize=None, fx=resize, fy=resize)
 
-                cv2.imshow("Preview"+str(im_counter), preview_im)
-                cv2.waitKey(1)
+                preview_images.append(preview_im)
 
-                im_counter += 1
-        # for frame in iter(image_queue.get, None):
-        #     cv2.imshow("Preview", cv2.cvtColor(frame['im'], cv2.COLOR_BAYER_RG2RGB))
-        #     # cv2.imshow("Preview", frame['im'])
-        #     cv2.waitKey(1)
+            h,w,d = preview_images[0].shape
+            # desired_zeros = np.zeros(preview_images[0].shape)
+            preview = np.zeros(np.array(preview_images[0].shape) * window_sizes[num_cams],dtype=np.uint8)
+
+            # removing padding code for now, making assumption that all cameras
+            # will have same sized images
+
+            im_counter = 0
+            w_offset = 0
+            h_offset = 0
+            for r in range(window_sizes[num_cams][0]):
+                for c in range(window_sizes[num_cams][1]):
+                    preview[h_offset:h_offset + h, w_offset:w_offset + w] = preview_images[im_counter]
+                    im_counter += 1
+                    w_offset += w
+
+                h_offset += h
+                w_offset = 0
+
+            cv2.imshow("Preview", preview)
+            cv2.waitKey(1)
 
 
     def write_queue(vid_file, image_queue, json_queue, serial):

--- a/dual_recording_ieee1588.py
+++ b/dual_recording_ieee1588.py
@@ -106,14 +106,15 @@ def record_dual(vid_file, max_frames=100, num_cams=4, frame_pause=0, preview = T
                         # if preview is enabled, save the size of the first image
                         # and append the image from each camera to a list
                         if preview:
-                            print("BEFORE RESIZE")
-                            print(resize,type(resize),im.shape)
+                            # print("BEFORE RESIZE")
+                            # print(resize,type(resize),im.shape)
+                            im_copy = copy.copy(cv2.cvtColor(im, cv2.COLOR_BAYER_RG2RGB))
                             if (0. < resize <= 1.0) and isinstance(resize,float):
-                                im_copy = copy.copy(cv2.cvtColor(im, cv2.COLOR_BAYER_RG2RGB))
+
                                 # im_copy = cv2.cvtColor(im_copy, cv2.COLOR_BAYER_RG2RGB)
-                                resize_factor = int(1/resize)
-                                print("RESIZE FACTOR",resize_factor)
-                                print("BEFORE")
+                                # resize_factor = int(1/resize)
+                                # print("RESIZE FACTOR",resize_factor)
+                                # print("BEFORE")
                                 # print(type(im))
                                 # print(type(im[0]))
                                 # print(type(im[0][0]))
@@ -123,7 +124,7 @@ def record_dual(vid_file, max_frames=100, num_cams=4, frame_pause=0, preview = T
                                 im_copy = cv2.resize(im_copy,dsize=None,fx=resize,fy=resize)
 
                                 # im = im[::resize_factor,::resize_factor]
-                                print("AFTER")
+                                # print("AFTER")
                                 # print(type(im))
                                 # print(type(im[0]))
                                 # print(type(im[0][0]))
@@ -135,9 +136,9 @@ def record_dual(vid_file, max_frames=100, num_cams=4, frame_pause=0, preview = T
                                 size_flag = 1
 
                                 image_size = im_copy.shape
-                                print("AFTER RESIZE",image_size)
+                                # print("AFTER RESIZE",image_size)
                     except Exception as e:
-                        print(e)
+                        # print(e)
                         tqdm.write('Bad frame')
                         continue
 

--- a/dual_recording_ieee1588.py
+++ b/dual_recording_ieee1588.py
@@ -103,40 +103,12 @@ def record_dual(vid_file, max_frames=100, num_cams=4, frame_pause=0, preview = T
                     try:
                         im = im.GetNDArray()
 
-                        # if preview is enabled, save the size of the first image
-                        # and append the image from each camera to a list
+
                         if preview:
-                            # print("BEFORE RESIZE")
-                            # print(resize,type(resize),im.shape)
-                            # im_copy = copy.copy(cv2.cvtColor(im, cv2.COLOR_BAYER_RG2RGB))
-                            # if (0. < resize <= 1.0) and isinstance(resize,float):
-
-                                # im_copy = cv2.cvtColor(im_copy, cv2.COLOR_BAYER_RG2RGB)
-                                # resize_factor = int(1/resize)
-                                # print("RESIZE FACTOR",resize_factor)
-                                # print("BEFORE")
-                                # print(type(im))
-                                # print(type(im[0]))
-                                # print(type(im[0][0]))
-                                # print(type(im[0][0][0]))
-                                # cv2.imshow("test1", im)
-                                # cv2.waitKey(1)
-                                # im_copy = cv2.resize(im_copy,dsize=None,fx=resize,fy=resize)
-
-                                # im = im[::resize_factor,::resize_factor]
-                                # print("AFTER")
-                                # print(type(im))
-                                # print(type(im[0]))
-                                # print(type(im[0][0]))
-                                # print(type(im[0][0][0]))
-                                # cv2.imshow("test",im_copy)
-                                # cv2.waitKey(1)
+                            # if preview is enabled, save the size of the first image
+                            # and append the image from each camera to a list
                             real_time_images.append(im)
-                            # if size_flag == 0:
-                            #     size_flag = 1
-                            #
-                            #     image_size = im_copy.shape
-                                # print("AFTER RESIZE",image_size)
+
                     except Exception as e:
                         # print(e)
                         tqdm.write('Bad frame')
@@ -146,7 +118,6 @@ def record_dual(vid_file, max_frames=100, num_cams=4, frame_pause=0, preview = T
                     image_queue_dict[c.DeviceSerialNumber].put({'im': im, 'real_times': real_times, 'timestamps': timestamps})
 
                 if preview:
-
                     # Add image list to queue if empty
                     if visualization_queue.empty():
                         visualization_queue.put({'im': real_time_images},block=False)
@@ -160,41 +131,8 @@ def record_dual(vid_file, max_frames=100, num_cams=4, frame_pause=0, preview = T
             image_queue_dict[c.DeviceSerialNumber].put(None)
 
     def visualize(image_queue):
-        print("VIS")
-        # if len(real_time_images) < np.prod(window_sizes[num_cams]):
-        #     # Add extra square to fill in empty space if there are
-        #     # not enough images to fit the current grid size
-        #     real_time_images.extend([np.zeros(real_time_images[0].shape, dtype=np.uint8) for i in
-        #                              range(np.prod(window_sizes[num_cams]) - len(real_time_images))])
-        #
-        # desired_width = image_size[1]
-        # desired_height = image_size[0]
-        #
-        # # create output visualization shape
-        # desired_zeros = np.zeros(real_time_images[0].shape, dtype=np.uint8)
-        # im_window = np.zeros_like(desired_zeros, shape=np.array(desired_zeros.shape) * window_sizes[num_cams])
-        #
-        # # removing padding code for now, making assumption that all cameras
-        # # will have same sized images
-        #
-        # im_counter = 0
-        # w_offset = 0
-        # h_offset = 0
-        # for r in range(window_sizes[num_cams][0]):
-        #     for c in range(window_sizes[num_cams][1]):
-        #         im_window[h_offset:h_offset + desired_height, w_offset:w_offset + desired_width] = real_time_images[
-        #             im_counter]
-        #         im_counter += 1
-        #         w_offset += desired_width
-        #
-        #     h_offset += desired_height
-        #     w_offset = 0
-        # frame = image_queue.get()
-        # print(frame)
-        # print(frame['im'])
-        # cv2.imshow("Preview", frame['im'][0])
-        # cv2.waitKey(1)
 
+        # Getting the image list from the queue
         for frame in iter(image_queue.get, None):
             real_time_images = frame['im']
 
@@ -209,20 +147,23 @@ def record_dual(vid_file, max_frames=100, num_cams=4, frame_pause=0, preview = T
                 if (0. < resize <= 1.0) and isinstance(resize, float):
                     preview_im = cv2.resize(preview_im, dsize=None, fx=resize, fy=resize)
 
+                # Add the color(/resized) images to a new list
                 preview_images.append(preview_im)
 
-            if len(real_time_images) < np.prod(window_sizes[num_cams]):
+            if len(preview_images) < np.prod(window_sizes[num_cams]):
                 # Add extra square to fill in empty space if there are
                 # not enough images to fit the current grid size
-                real_time_images.extend([np.zeros(preview_images[0].shape, dtype=np.uint8) for i in range(np.prod(window_sizes[num_cams]) - len(preview_images))])
+                preview_images.extend([np.zeros(preview_images[0].shape, dtype=np.uint8) for i in range(np.prod(window_sizes[num_cams]) - len(preview_images))])
 
             h,w,d = preview_images[0].shape
-            # desired_zeros = np.zeros(preview_images[0].shape)
+
+            # Initializing the full output grid
             preview = np.zeros(np.array(preview_images[0].shape) * window_sizes[num_cams],dtype=np.uint8)
 
             # removing padding code for now, making assumption that all cameras
             # will have same sized images
 
+            # Filling in the full grid with individual images
             im_counter = 0
             w_offset = 0
             h_offset = 0
@@ -235,6 +176,7 @@ def record_dual(vid_file, max_frames=100, num_cams=4, frame_pause=0, preview = T
                 h_offset += h
                 w_offset = 0
 
+            # Display the preview image
             cv2.imshow("Preview", preview)
             cv2.waitKey(1)
 

--- a/dual_recording_ieee1588.py
+++ b/dual_recording_ieee1588.py
@@ -198,10 +198,8 @@ def record_dual(vid_file, max_frames=100, num_cams=4, frame_pause=0, preview = T
         for frame in iter(image_queue.get, None):
             real_time_images = frame['im']
 
-            # print(type(real_time_images))
-
             preview_images = []
-            im_counter = 0
+
             for i in real_time_images:
 
                 # Go through the list of images, and convert them all to color
@@ -212,6 +210,11 @@ def record_dual(vid_file, max_frames=100, num_cams=4, frame_pause=0, preview = T
                     preview_im = cv2.resize(preview_im, dsize=None, fx=resize, fy=resize)
 
                 preview_images.append(preview_im)
+
+            if len(real_time_images) < np.prod(window_sizes[num_cams]):
+                # Add extra square to fill in empty space if there are
+                # not enough images to fit the current grid size
+                real_time_images.extend([np.zeros(preview_images[0].shape, dtype=np.uint8) for i in range(np.prod(window_sizes[num_cams]) - len(preview_images))])
 
             h,w,d = preview_images[0].shape
             # desired_zeros = np.zeros(preview_images[0].shape)


### PR DESCRIPTION
This branch adds the option to resize the preview window for real-time visualization and moves any computations related to real-time visualization to a separate thread. If 'preview' is active, the images will be resized by a factor of 0.5 by default, but any desired ratio between 0 and 1 can be passed as an argument. 